### PR TITLE
remove Arduino in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,4 +1,4 @@
-name=Arduino Fast ST7789 Library
+name=Fast ST7789 Library
 version=1.0.4
 author=Pawel A. Hernik
 maintainer=Pawel A. Hernik <pawelhernik123@gmail.com>


### PR DESCRIPTION
To be compliant with Libraries Manager FAQ and. be referenced in the librairie Manager ofthe. Arduino IDE